### PR TITLE
Fix 'cache' and 'clean' behaviour

### DIFF
--- a/lib/docker/template/cache.rb
+++ b/lib/docker/template/cache.rb
@@ -17,12 +17,10 @@ module Docker
         builder.repo.cache_dir.rm_rf
         $stderr.puts Simple::Ansi.yellow(format("Copying context for %s", builder.repo))
         cache_dir = builder.repo.cache_dir
-        cache_dir.parent.mkdir_p
+        cache_dir.mkdir_p
 
         readme(builder)
-        context.cp_r(cache_dir.tap(
-          &:rm_rf
-        ))
+        context.join(".").cp_r(cache_dir)
       end
 
       # ----------------------------------------------------------------------
@@ -45,9 +43,10 @@ module Docker
       # ----------------------------------------------------------------------
 
       def cleanup(repo)
+        return unless repo.clean_cache?
         cache_dir = repo.cache_dir.parent
 
-        if repo.cacheable? && cache_dir.exist?
+        if cache_dir.exist?
           then cache_dir.children.each do |file|
             next unless repo.meta.tags.include?(file.basename)
             $stdout.puts Simple::Ansi.yellow(format("Removing %s.",
@@ -70,7 +69,7 @@ module Docker
         end
 
         return unless file
-        file.safe_copy(builder.repo.cache_dir, {
+        file.safe_copy(builder.repo.cache_dir.join(file.basename), {
           :root => file.parent
         })
       end

--- a/lib/docker/template/cli.rb
+++ b/lib/docker/template/cli.rb
@@ -21,6 +21,7 @@ module Docker
         return help(__method__) if options.help?
         self.options = options.merge(:cache => true) if options.force?
         self.options = options.merge(:cache_only => true)
+        self.options = options.merge(:clean => false)
         return build(
           *args
         )

--- a/lib/docker/template/repo.rb
+++ b/lib/docker/template/repo.rb
@@ -41,6 +41,12 @@ module Docker
 
       # --
 
+      def clean_cache?
+        (meta["clean"] || meta["clean_only"])
+      end
+
+      # --
+
       def buildable?
         meta.build? && !meta["push_only"] && !meta["cache_only"] &&
           !meta[


### PR DESCRIPTION
Considering the existence of 'clean' command and '--clean' / '--no-clean' flags in 'build' command, it does not make sense always clean up the caches at the teardown. Thus, there is no use caching, moving from 'tmp' to 'repos/[repo]/cache', the Dockerfiles just to remove independently of the flags passed. Therefore, this is what I expected as the CLI behaviour accordingly with its interface (commands):

When 'clean' or 'build --clean' is executed, cache is ALWAYS cleaned up
When 'cache' or 'build --cache' is executed, cache is generated and NOT cleaned up, unless '--clean' is also provided
When 'build --no-cache' is executed, cache is NOT generated, whether exists or not
When 'build --no-clean' is executed, cache is NOT cleaned up, whether exists or not
Opts.yml with 'only_cache: true' or 'cache: true' behaves as 'build --cache'
Opts.yml with 'only_cache: false' or 'cache: false' behaves as 'build --no-cache'
Opts.yml with 'clean: true' behaves as 'build --clean'
Opts.yml with 'clean: false' behaves as 'build --no-clean'

It also fixes copy of README file to cache, that was overridden while copying Dockerfile to cache dir.