### PR TITLE
Fix noclean cache

### DIFF
--- a/lib/docker/template/cache.rb
+++ b/lib/docker/template/cache.rb
@@ -43,9 +43,10 @@ module Docker
       # --
 
       def cleanup(repo)
+        return unless repo.clean_cache?
         cache_dir = repo.cache_dir.parent
 
-        if repo.cacheable? && cache_dir.exist?
+        if cache_dir.exist?
           cache_dir.children.each do |file|
             next unless repo.meta.tags.include?(file.basename)
             $stdout.puts Simple::Ansi.yellow(format("Removing %s.",

--- a/lib/docker/template/cli.rb
+++ b/lib/docker/template/cli.rb
@@ -13,6 +13,7 @@ module Docker
 
       option :force, :type => :boolean, :desc => "Force caching."
       desc "cache [REPOS [OPTS]]", "Cache all (or some) of your repositories."
+      option :clean, :type => :boolean, :desc => "Cleanup your caches."
       option :help, :type => :boolean, :desc => "Output this."
 
       # --

--- a/lib/docker/template/repo.rb
+++ b/lib/docker/template/repo.rb
@@ -41,6 +41,12 @@ module Docker
 
       # --
 
+      def clean_cache?
+        (meta["clean"] || meta["clean_only"])
+      end
+
+      # --
+
       def buildable?
         meta.build? && !meta["push_only"] && !meta["cache_only"] &&
           !meta[


### PR DESCRIPTION
This is a rewrite of the pull request #22 that had to be reverted.

It is meant to fix the same problem: the application cleans up the cache, even when `--no-cache` is passed or `clean: false` into `Opts.yml`.

Differently from the previous pull request, it does not change the default behaviour. At least, is meant to not do it. I have tested in several scenarios. I can't say about the other scenarios you use it in. I hope you can check them and that it works. Any problem, please report so I can fix ASAP.

I've implemented, as you noticed before, and will see again, a short-circuit to skip cache clean up. The first line of the `Cache.cleanup()` returns immediately, cleaning no cache, when both `Repo.meta["clean"]` and `Repo.meta["clean"]` are `false`. This is to be the case only when:
- `docker-template build/cache --no-clean`
- Opts.yml contains `clean: false`

The `docker-template build/cache --clean | --no-clean` prevails over `Opts.yml`.  Also, the default behaviour, implemented in `Meta.DEFAULTS` is respected when neither the options `--clean | --no-clean` is passed or `cache: true | false` in `Opts.yml` exists. This means:

| opts.yml { clean } | docker-template build/cache options |  cleanup       |
|--------------------|-------------------------------------|----------------|
| `false`            | **none**                            | **no clean**   |
| `false`            | `--clean`                           | **clean**      |
| `false`            | `--no-clean`                        | **no clean**   |
| `true`             |  **none**                           | **clean**      |
| `true`             | `--clean`                           | **clean**      |
| `true`             | `--no-clean`                        | **no clean**   |
| **nil**            |  **none**                           | `Meta.DEFAULTS.clean` |
| **nil**            | `--clean`                           | **clean**      |
| **nil**            | `--no-clean`                        | **no clean**   |
