### PR TITLE
Fix cache of README

### DIFF
--- a/lib/docker/template/cache.rb
+++ b/lib/docker/template/cache.rb
@@ -17,10 +17,10 @@ module Docker
         cache_dir = builder.repo.cache_dir
         cache_dir.parent.mkdir_p
 
-        readme(builder)
         context.cp_r(cache_dir.tap(
           &:rm_rf
         ))
+        readme(builder)
       end
 
       # --


### PR DESCRIPTION
Fix copying the README file from `[repo]/README` to `[repo]/cache/[tag]/README`.

Copy of the README was been called before copying `/tmp/[repo]-[tag]-[random]` to `[repo]/cache/[tag]/`. Therefore, when the file was copied, it was created as `[repo]/cache/[tag]`, because the destination folder didn't exists.

Latter, the `/tmp/[repo]-[tag]-[random]` copy as `[repo]/cache/[tag]` as well, always replaced the file.

Changing the order fixes this because when the README file is copied, the `[repo]/cache/[tag]` now exists, copying it correctly as `[repo]/cache/[tag]/README`.
