### PR TITLE
README: Drop non-working badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
 # Docker Template
 
 [![Build](https://travis-ci.org/envygeeks/docker-template.svg?branch=master)][travis]
-[![Test](https://codeclimate.com/github/envygeeks/docker-template/badges/coverage.svg)][coverage]
-[![Code](https://codeclimate.com/github/envygeeks/docker-template/badges/gpa.svg)][codeclimate]
-[![Dependency](https://gemnasium.com/envygeeks/docker-template.svg)][gemnasium]
 
-[gemnasium]: https://gemnasium.com/envygeeks/docker-template
-[codeclimate]: https://codeclimate.com/github/envygeeks/docker-template
-[coverage]: https://codeclimate.com/github/envygeeks/docker-template/coverage
 [travis]: https://travis-ci.org/envygeeks/docker-template
 
 Docker Template is an organization and templating system for Docker images. A way to make your life easier and more organized by having repositories within repositories that share data among multiple sets of images.  It is currently used to build all the images for Jekyll and EnvyGeeks.  Please see https://github.com/envygeeks/docker-template/wiki for documentation.


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [ ] I have verified that the specs/tests pass on my computer.
- [ ] I have not attempted to bump, or alter versions.
- [x] This is a documentation change.
- [ ] This is a source change.

## Description

This PR changes the README to avoid broken badges.

1. gemnasium closed
2. codeclimate does not seem to be set up for the repo